### PR TITLE
Change docker image name

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker build -t piotreczek481/potter-shop:latest .
+          docker build -t piotreczek481/be_188667_prestashop:latest .
 
       - name: Push Docker Image
         run: |
-          docker push piotreczek481/potter-shop:latest
+          docker push piotreczek481/be_188667_prestashop:latest


### PR DESCRIPTION
This pull request includes changes to the Docker build and push steps in the GitHub Actions workflow to update the Docker image tags.

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L24-R28): Updated the Docker image tag from `piotreczek481/potter-shop:latest` to `piotreczek481/be_188667_prestashop:latest` in both the build and push steps.